### PR TITLE
adapt to jupyterlab-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.1.3",
-    "@jupyterlab/codemirror": "^1.1.3",
-    "@jupyterlab/notebook": "^1.1.3",
+    "@jupyterlab/application": "^2.0.0",
+    "@jupyterlab/codemirror": "^2.0.0",
+    "@jupyterlab/notebook": "^2.0.0",
     "@types/codemirror": "^0.0.79",
     "@types/lodash": "^4.14.144",
     "lodash": "^4.17.15"


### PR DESCRIPTION
This simple change can make this extension adapt to jupyterlab-2.0.0.
Examined upder Mac OS Sierra.

